### PR TITLE
댓글, 스크랩, 좋아요 저장 및 조회

### DIFF
--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -3,8 +3,12 @@ package sogong.sogongSpring.controller
 import lombok.RequiredArgsConstructor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
+import sogong.sogongSpring.dto.EntireCommentDto
 import sogong.sogongSpring.dto.EntirePostDto
+import sogong.sogongSpring.dto.ScrapLikeDto
+import sogong.sogongSpring.entity.EntireCommentEntity
 import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.entity.ScrapLikeEntity
 import sogong.sogongSpring.service.BoardService
 
 
@@ -18,8 +22,19 @@ class BoardController {
         this.boardService = boardService
     }
 
-    @PostMapping("/edit")
-    fun EditPost(@RequestBody entirePostDto : EntirePostDto): MutableList<EntirePostEntity> {
+    @PostMapping("/registPost")
+    fun registPost(@RequestBody entirePostDto : EntirePostDto): MutableList<EntirePostEntity> {
         return boardService.saveBoard(entirePostDto) //바로 Service로 갑니다^^
     }
+
+    @PostMapping("/registComment")
+    fun registComment(@RequestBody entireCommentDto : EntireCommentDto) : MutableList<EntireCommentEntity>{
+        return boardService.saveComment(entireCommentDto)
+    }
+
+    @PostMapping("/saveScrapLike")
+    fun registScrapLike(@RequestBody scrapLikeDto: ScrapLikeDto) : MutableList<ScrapLikeEntity>{
+        return boardService.saveScrapLike(scrapLikeDto)
+    }
+
 }

--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -1,15 +1,18 @@
 package sogong.sogongSpring.controller
 
-import lombok.RequiredArgsConstructor
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
-import sogong.sogongSpring.dto.EntireCommentDto
-import sogong.sogongSpring.dto.EntirePostDto
-import sogong.sogongSpring.dto.ScrapLikeDto
+import sogong.sogongSpring.dto.boardedit.EditPostCommentAuthDto
+import sogong.sogongSpring.dto.board.EntireCommentDto
+import sogong.sogongSpring.dto.board.EntirePostDto
+import sogong.sogongSpring.dto.board.ScrapLikeDto
+import sogong.sogongSpring.dto.boardedit.DeleteCommentDto
+import sogong.sogongSpring.dto.boardedit.DeletePostDto
+import sogong.sogongSpring.dto.boardprint.PrintEntirePostDto
 import sogong.sogongSpring.entity.EntireCommentEntity
 import sogong.sogongSpring.entity.EntirePostEntity
-import sogong.sogongSpring.entity.ScrapLikeEntity
 import sogong.sogongSpring.service.BoardService
+import sogong.sogongSpring.service.BoardEditService
+import sogong.sogongSpring.service.BoardPrintService
 
 
 @RestController // JSON 형태로 결과 반환해줌!
@@ -17,24 +20,68 @@ import sogong.sogongSpring.service.BoardService
 @RequestMapping("/board")
 class BoardController {
     var boardService : BoardService
+    var boardServiceEdit : BoardEditService
+    var boardPrintService : BoardPrintService
 
-    constructor(boardService: BoardService){
+    constructor(boardService: BoardService, boardServiceEdit: BoardEditService, boardPrintService: BoardPrintService){
         this.boardService = boardService
+        this.boardServiceEdit = boardServiceEdit
+        this.boardPrintService = boardPrintService
     }
 
     @PostMapping("/registPost")
-    fun registPost(@RequestBody entirePostDto : EntirePostDto): MutableList<EntirePostEntity> {
+    fun registPost(@RequestBody entirePostDto : EntirePostDto): EntirePostEntity {
         return boardService.saveBoard(entirePostDto) //바로 Service로 갑니다^^
     }
 
     @PostMapping("/registComment")
-    fun registComment(@RequestBody entireCommentDto : EntireCommentDto) : MutableList<EntireCommentEntity>{
+    fun registComment(@RequestBody entireCommentDto : EntireCommentDto) : EntireCommentEntity{
         return boardService.saveComment(entireCommentDto)
     }
 
     @PostMapping("/saveScrapLike")
-    fun registScrapLike(@RequestBody scrapLikeDto: ScrapLikeDto) : MutableList<ScrapLikeEntity>{
-        return boardService.saveScrapLike(scrapLikeDto)
+    fun registScrapLike(@RequestBody scrapLikeDto: ScrapLikeDto){
+        boardService.saveScrapLike(scrapLikeDto)
     }
 
+    @PostMapping(value = ["/editPostAuth", "/editCommentAuth"])
+    fun editAuth(@RequestBody editPostCommentDto: EditPostCommentAuthDto) : Boolean{
+        return boardServiceEdit.editAuth(editPostCommentDto)
+    }
+
+    @PostMapping("/editPost")
+    fun editPost(@RequestBody editPostDto : EntirePostDto) : EntirePostEntity{
+        return boardServiceEdit.editPost(editPostDto)
+    }
+
+    @PostMapping("/editComment")
+    fun editComment(@RequestBody editCommentDto : EntireCommentDto) {
+        boardServiceEdit.editComment(editCommentDto)
+    }
+
+    @PostMapping("/deleteComment")
+    fun deleteComment(@RequestBody deleteCommentDto: DeleteCommentDto){
+        boardServiceEdit.deleteComment(deleteCommentDto)
+    }
+
+    @PostMapping("/deletePost")
+    fun deletePost(@RequestBody deletePostDto: DeletePostDto){
+        boardServiceEdit.deletePost(deletePostDto)
+    }
+
+    @GetMapping("/printEntirePost")
+    fun printPost() : MutableList<PrintEntirePostDto>{
+        return boardPrintService.printEntirePost()
+    }
+
+    @GetMapping("/printCommentByPost")
+    fun printComment(@RequestParam("postId") postId : Long): MutableList<EntireCommentDto>{
+        return boardPrintService.printComment(postId)
+    }
+
+    @GetMapping("/printScrapLike")
+    fun printScrapLike(@RequestParam("userId") userId:Long,
+                       @RequestParam("scrapLike") scrapLike:Boolean) : MutableList<PrintEntirePostDto>{
+        return boardPrintService.printScrapLike(userId, scrapLike)
+    }
 }

--- a/src/main/kotlin/sogong/sogongSpring/dto/BestPostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/BestPostDto.kt
@@ -6,5 +6,5 @@ import java.util.*
 data class BestPostDto(
     val bestid: Long? = null,
     val postid: Long,
-    var date: Date
+    var date: Date? = null //수정 예정
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/EntireCommentDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/EntireCommentDto.kt
@@ -7,6 +7,6 @@ data class EntireCommentDto(
     val commentid: Long? = null,
     val userid: Long,
     val postid: Long,
-    var date: Date,
+    var date: Date ?= null, //수정 예정
     var content: String
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/HotPostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/HotPostDto.kt
@@ -6,5 +6,5 @@ import java.util.*
 data class HotPostDto(
     val hotid: Long? = null,
     val postid: Long,
-    var date: Date
+    var date: Date? = null //수정 예정
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/UserLoginDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/UserLoginDto.kt
@@ -3,11 +3,12 @@ package sogong.sogongSpring.dto
 import java.io.Serializable
 import java.util.*
 
+//class 전체적으로 손 볼 예정
 data class UserLoginDto(
     val userid: Long? = null,
     val name: String,
     var passwd: String? = null,
-    var bday: Date,
+    var bday: Date? = null, //수정 예정
     val phone: String,
     val social: Boolean,
     var business: Boolean,

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/EntireCommentDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/EntireCommentDto.kt
@@ -1,4 +1,4 @@
-package sogong.sogongSpring.dto
+package sogong.sogongSpring.dto.board
 
 import java.io.Serializable
 import java.util.*

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/EntirePostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/EntirePostDto.kt
@@ -1,4 +1,4 @@
-package sogong.sogongSpring.dto
+package sogong.sogongSpring.dto.board
 
 import java.io.Serializable
 import java.util.*

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/ScrapLikeDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/ScrapLikeDto.kt
@@ -1,4 +1,4 @@
-package sogong.sogongSpring.dto
+package sogong.sogongSpring.dto.board
 
 import java.io.Serializable
 

--- a/src/main/kotlin/sogong/sogongSpring/dto/boardedit/DeleteCommentDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/boardedit/DeleteCommentDto.kt
@@ -1,0 +1,6 @@
+package sogong.sogongSpring.dto.boardedit
+
+data class DeleteCommentDto(
+    val commentid : Long,
+    val postid : Long
+) : java.io.Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/boardedit/DeletePostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/boardedit/DeletePostDto.kt
@@ -1,0 +1,5 @@
+package sogong.sogongSpring.dto.boardedit
+
+data class DeletePostDto(
+    val postid : Long
+):java.io.Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/boardedit/EditPostCommentAuthDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/boardedit/EditPostCommentAuthDto.kt
@@ -1,0 +1,9 @@
+package sogong.sogongSpring.dto.boardedit
+
+import java.io.Serializable
+
+data class EditPostCommentAuthDto(
+    val postid : Long,
+    val userid : Long,
+    val commentid : Long ?= null
+) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/boardprint/PrintEntirePostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/boardprint/PrintEntirePostDto.kt
@@ -1,0 +1,13 @@
+package sogong.sogongSpring.dto.boardprint
+
+import java.io.Serializable
+import java.util.*
+
+data class PrintEntirePostDto(
+    val postid : Long,
+    val userid : Long,
+    val subject : String,
+    val date : Date,
+    val countcomment:Int,
+    val countlike:Int
+):Serializable

--- a/src/main/kotlin/sogong/sogongSpring/entity/BasicLoginEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/BasicLoginEntity.kt
@@ -7,14 +7,14 @@ import javax.persistence.*
 data class BasicLoginEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val basicid : Long,
+    val basicId : Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userid", nullable = false)
-    val userid : UserLoginEntity,
+    @JoinColumn(name = "userId", nullable = false)
+    val userId : UserLoginEntity,
 
     @Column(nullable = false, length = 15)
-    val realid : String,
+    val realId : String,
 
     @Column(nullable = false, length = 20)
     var passwd : String

--- a/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
@@ -11,7 +11,7 @@ import javax.persistence.*
 data class BestPostEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val bestid : Long,
+    val bestid : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "postid", nullable = false)

--- a/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
@@ -11,11 +11,11 @@ import javax.persistence.*
 data class BestPostEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val bestid : Long? = null,
+    val bestId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postid", nullable = false)
-    val postid : EntirePostEntity,
+    @JoinColumn(name = "postId", nullable = false)
+    val postId : EntirePostEntity,
 
     @Column(nullable = false)
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
@@ -12,17 +12,17 @@ import javax.persistence.*
 data class EntireCommentEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val commentid :Long? = null,
+    val commentId :Long? = null,
 
     @ManyToOne(fetch=FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name="userid",nullable = false)
-    val userid : UserLoginEntity,
+    @JoinColumn(name="userId",nullable = false)
+    val userId : UserLoginEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name="postid",nullable = false)
-    val postid : EntirePostEntity,
+    @JoinColumn(name="postId",nullable = false)
+    val postId : EntirePostEntity,
 
     @Column(nullable = false)
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
@@ -1,5 +1,6 @@
 package sogong.sogongSpring.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import lombok.NoArgsConstructor
 import org.springframework.format.annotation.DateTimeFormat
 import java.util.Date
@@ -11,13 +12,15 @@ import javax.persistence.*
 data class EntireCommentEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val commentid :Long ,
+    val commentid :Long? = null,
 
     @ManyToOne(fetch=FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name="userid",nullable = false)
     val userid : UserLoginEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name="postid",nullable = false)
     val postid : EntirePostEntity,
 

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
@@ -13,12 +13,12 @@ import javax.persistence.*
 data class EntirePostEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val postid: Long? = null,
+    val postId: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name = "userid", nullable = false)
-    val userid: UserLoginEntity,
+    @JoinColumn(name = "userId", nullable = false)
+    val userId: UserLoginEntity,
 
     @Column(nullable = false, length = 30)
     var subject: String,
@@ -38,8 +38,8 @@ data class EntirePostEntity(
     var hashtag: String,
 
     @Column(columnDefinition = "integer default 0")
-    var countcomment: Int = 0,
+    var countComment: Int = 0,
 
     @Column(columnDefinition = "integer default 0")
-    var countlike: Int = 0
+    var countLike: Int = 0
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
@@ -9,8 +9,8 @@ import javax.persistence.*
 data class HashtagDbEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val hashid : Long? = null,
+    val hashId : Long? = null,
 
     @Column(nullable = false, length = 45)
-    val hashname : String
+    val hashName : String
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
@@ -9,7 +9,7 @@ import javax.persistence.*
 data class HashtagDbEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val hashid : Long,
+    val hashid : Long? = null,
 
     @Column(nullable = false, length = 45)
     val hashname : String

--- a/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
@@ -11,7 +11,7 @@ import javax.persistence.*
 data class HotPostEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val hotid : Long,
+    val hotid : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="postid",nullable = false)

--- a/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
@@ -11,11 +11,11 @@ import javax.persistence.*
 data class HotPostEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val hotid : Long? = null,
+    val hotId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="postid",nullable = false)
-    val postid : EntirePostEntity,
+    @JoinColumn(name="postId",nullable = false)
+    val postId : EntirePostEntity,
 
     @Column(nullable = false)
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/kotlin/sogong/sogongSpring/entity/ScrapLikeEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/ScrapLikeEntity.kt
@@ -10,17 +10,17 @@ import javax.persistence.*
 data class ScrapLikeEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val scrapid : Long? = null,
+    val scrapId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name="userid",nullable = false)
-    val userid : UserLoginEntity,
+    @JoinColumn(name="userId",nullable = false)
+    val userId : UserLoginEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name="postid",nullable = false)
-    val postid : EntirePostEntity,
+    @JoinColumn(name="postId",nullable = false)
+    val postId : EntirePostEntity,
 
     @Column(nullable = false, columnDefinition = "TINYINT", length = 1)
     val category : Boolean

--- a/src/main/kotlin/sogong/sogongSpring/entity/ScrapLikeEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/ScrapLikeEntity.kt
@@ -1,5 +1,6 @@
 package sogong.sogongSpring.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import lombok.NoArgsConstructor
 import javax.persistence.*
 
@@ -9,13 +10,15 @@ import javax.persistence.*
 data class ScrapLikeEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val scrapid : Long,
+    val scrapid : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name="userid",nullable = false)
     val userid : UserLoginEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name="postid",nullable = false)
     val postid : EntirePostEntity,
 

--- a/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
@@ -10,16 +10,16 @@ import javax.persistence.*
 data class UserHashtagEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val userhashid : Long? = null,
+    val userHashId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="userid", nullable = false)
-    val userid : UserLoginEntity,
+    @JoinColumn(name="userId", nullable = false)
+    val userId : UserLoginEntity,
 
     @Column(nullable = false)
-    var groupid : Long? = null,
+    var groupiId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="hashid", nullable = false)
-    var hashid : HashtagDbEntity
+    @JoinColumn(name="hashId", nullable = false)
+    var hashId : HashtagDbEntity
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.*
 data class UserHashtagEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val userhashid : Long,
+    val userhashid : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="userid", nullable = false)

--- a/src/main/kotlin/sogong/sogongSpring/entity/UserLoginEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/UserLoginEntity.kt
@@ -14,28 +14,28 @@ import javax.persistence.GenerationType.IDENTITY
 data class UserLoginEntity(
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private val userid: Long? = null,
+    val userId: Long? = null,
 
     @Column(length = 45, nullable = false)
-    private val name: String,
+    val name: String,
 
     @Column(nullable = true)
-    private var passwd: String? = null,
+    var passwd: String? = null,
 
     @Column(nullable = false)
     @Temporal(TemporalType.DATE)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private var bday: Date,
+    var bday: Date,
 
     @Column(length = 11, nullable = false)
-    private val phone: String,
+    val phone: String,
 
     @Column(nullable = false, columnDefinition = "TINYINT", length = 1)
-    private val social: Boolean,
+    val social: Boolean,
 
     @Column(nullable = false, columnDefinition = "TINYINT", length = 1)
-    private var business: Boolean,
+    var business: Boolean,
 
     @Column(length = 50)
-    private var sectors: String? = null
+    var sectors: String? = null
 )

--- a/src/main/kotlin/sogong/sogongSpring/repository/EntireCommentRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/EntireCommentRepository.kt
@@ -3,7 +3,11 @@ package sogong.sogongSpring.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import sogong.sogongSpring.entity.EntireCommentEntity
+import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.entity.UserLoginEntity
 
 @Repository
 interface EntireCommentRepository : JpaRepository<EntireCommentEntity, Long> {
+    fun findByCommentIdAndUserIdAndPostId(commentId:Long, userId:UserLoginEntity, postId:EntirePostEntity) : List<EntireCommentEntity>
+    fun findByPostId(postId:EntirePostEntity) : List<EntireCommentEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
@@ -3,8 +3,9 @@ package sogong.sogongSpring.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.entity.UserLoginEntity
 
 @Repository
 interface EntirePostRepository : JpaRepository<EntirePostEntity, Long> {
-    fun findByContent(content:String):List<EntirePostEntity>
+    fun findByPostIdAndUserId(postId:Long, userId:UserLoginEntity):List<EntirePostEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/ScrapLikeRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/ScrapLikeRepository.kt
@@ -6,4 +6,7 @@ import sogong.sogongSpring.entity.*
 
 @Repository
 interface ScrapLikeRepository : JpaRepository<ScrapLikeEntity, Long> {
+    fun findByUserIdAndPostIdAndCategory(userId:UserLoginEntity, postId:EntirePostEntity, category:Boolean) : ScrapLikeEntity?
+    fun findByPostId(postId:EntirePostEntity):List<ScrapLikeEntity>
+    fun findByUserIdAndCategory(userId:UserLoginEntity, category: Boolean):List<ScrapLikeEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
@@ -1,0 +1,104 @@
+package sogong.sogongSpring.service
+
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import sogong.sogongSpring.dto.boardedit.EditPostCommentAuthDto
+import sogong.sogongSpring.dto.board.EntireCommentDto
+import sogong.sogongSpring.dto.board.EntirePostDto
+import sogong.sogongSpring.dto.boardedit.DeleteCommentDto
+import sogong.sogongSpring.dto.boardedit.DeletePostDto
+import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.repository.EntireCommentRepository
+import sogong.sogongSpring.repository.EntirePostRepository
+import sogong.sogongSpring.repository.ScrapLikeRepository
+import sogong.sogongSpring.repository.UserLoginRepository
+import java.util.*
+import javax.transaction.Transactional
+
+
+@Service
+class BoardEditService {
+    @Autowired //글을 저장하려는 변수
+    lateinit var entirePostRepository : EntirePostRepository
+    @Autowired //글을 저장할 때 userid가 유효한지 검증하려는 변수
+    lateinit var userLoginRepository : UserLoginRepository
+    @Autowired //댓글을 저장하려는 변수
+    lateinit var entireCommentRepository: EntireCommentRepository
+    @Autowired
+    lateinit var scrapLikeRepository: ScrapLikeRepository
+
+    ///////////////////////////////////////////////////////////////
+    @Transactional
+    fun editAuth(editPostCommentAuthDto: EditPostCommentAuthDto) : Boolean{
+        val userAuth = userLoginRepository.findById(editPostCommentAuthDto.userid) //기본적으로 userid부터 조회해야 함
+
+        if(userAuth.isPresent){
+            if(editPostCommentAuthDto.commentid == null) { //글 수정 권한 조회일 경우
+                val postAuth = entirePostRepository.findByPostIdAndUserId(editPostCommentAuthDto.postid, userAuth.get())
+                return postAuth.isNotEmpty()
+            }
+            else{ //댓글 수정 권한 조회일 경우
+                val postAuth = entirePostRepository.findById(editPostCommentAuthDto.postid)
+                if(postAuth.isPresent){
+                    val commentAuth = entireCommentRepository.findByCommentIdAndUserIdAndPostId(
+                        editPostCommentAuthDto.commentid, userAuth.get(), postAuth.get()
+                    )
+                    return commentAuth.isNotEmpty()
+                }
+                else throw java.lang.IllegalArgumentException("Postid Error!!") //postid가 잘못 되었을 경우
+            }
+        }
+        else throw java.lang.IllegalArgumentException("Userid Error!!") //userid가 잘못 되었을 경우
+    }
+
+    ///////////////////////////////////////////////////////////////
+    @Transactional
+    fun editPost(editPostDto : EntirePostDto) : EntirePostEntity{
+        //Dto를 재활용하는 바람에 글 생성될 때 null 허용하던 postid가 여기선 not null로 처리해야되는...
+        //Dto 하나 더 만들까 생각 중.
+        val editPost = entirePostRepository.findById(editPostDto.postid!!).get()
+
+        editPost.subject = editPostDto.subject
+        editPost.content = editPostDto.content
+        editPost.date = Date()
+        editPost.picture = editPostDto.picture
+        editPost.hashtag = editPostDto.hashtag
+        //공백 subject, content는 어떻게 처리?
+
+        return editPost
+    }
+
+    @Transactional
+    fun editComment(editCommentDto : EntireCommentDto){
+        val editComment = entireCommentRepository.findById(editCommentDto.commentid!!).get()
+        editComment.date = Date()
+        editComment.content = editCommentDto.content
+        //공백 content는 어떻게 처리?
+    }
+
+    @Transactional
+    fun deleteComment(deleteCommentDto: DeleteCommentDto){
+        if (entireCommentRepository.findById(deleteCommentDto.commentid).get().postId.postId == deleteCommentDto.postid) {
+            entireCommentRepository.deleteById(deleteCommentDto.commentid)
+            val decreaseCount = entirePostRepository.findById(deleteCommentDto.postid).get()
+            decreaseCount.countComment = decreaseCount.countComment - 1
+        }
+        else throw java.lang.IllegalArgumentException("Userid Error!!")
+    }
+
+    @Transactional
+    fun deletePost(deletePostDto: DeletePostDto){
+        //==========hotpost 에서도 삭제해야함 참고=============//
+        val deletePost = entirePostRepository.findById(deletePostDto.postid)
+        if (deletePost.isPresent) {
+            val deleteScrapLike = scrapLikeRepository.findByPostId(deletePost.get())
+            val deletecomment = entireCommentRepository.findByPostId(deletePost.get())
+
+            deleteScrapLike.forEach { i -> scrapLikeRepository.delete(i) }
+            deletecomment.forEach { i -> entireCommentRepository.delete(i) }
+            entirePostRepository.deleteById(deletePostDto.postid)
+        }
+        else throw java.lang.IllegalArgumentException("PostId Error!!")
+    }
+}

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
@@ -1,0 +1,68 @@
+package sogong.sogongSpring.service
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.RequestMapping
+import sogong.sogongSpring.dto.board.EntireCommentDto
+import sogong.sogongSpring.dto.boardprint.PrintEntirePostDto
+import sogong.sogongSpring.entity.EntireCommentEntity
+import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.entity.UserLoginEntity
+import sogong.sogongSpring.repository.EntireCommentRepository
+import sogong.sogongSpring.repository.EntirePostRepository
+import sogong.sogongSpring.repository.ScrapLikeRepository
+import sogong.sogongSpring.repository.UserLoginRepository
+
+@Service
+class BoardPrintService {
+
+    @Autowired
+    lateinit var entirePostRepository : EntirePostRepository
+    @Autowired
+    lateinit var entireCommentRepository: EntireCommentRepository
+    @Autowired
+    lateinit var userLoginRepository: UserLoginRepository
+    @Autowired
+    lateinit var scrapLikeRepository: ScrapLikeRepository
+
+    @RequestMapping
+    fun printEntirePost() : MutableList<PrintEntirePostDto>{
+        val postList : MutableList<PrintEntirePostDto> = ArrayList()
+        val entirePost = entirePostRepository.findAll()
+        entirePost.forEach{ i ->
+            postList.add(PrintEntirePostDto(i.postId!!, i.userId.userId!!, i.subject
+                , i.date, i.countComment, i.countLike))
+        }
+        return postList
+    }
+
+    @RequestMapping
+    fun printComment(postId:Long):MutableList<EntireCommentDto>{
+        val commentList : MutableList<EntireCommentDto> = ArrayList()
+        val findPost = entirePostRepository.findById(postId)
+        val findComment = entireCommentRepository.findByPostId(findPost.get())
+
+        findComment.forEach { i ->
+            commentList.add(
+                EntireCommentDto(i.commentId, i.userId.userId!!,
+                i.postId.postId!!, i.date, i.content)
+            )
+        }
+        return commentList
+    }
+
+    @RequestMapping
+    fun printScrapLike(userId:Long, scrapLike:Boolean):MutableList<PrintEntirePostDto>{
+        val scrapLikeList : MutableList<PrintEntirePostDto> = ArrayList()
+        val findUser = userLoginRepository.findById(userId)
+        val findScrapLike = scrapLikeRepository.findByUserIdAndCategory(findUser.get(), scrapLike)
+
+        findScrapLike.forEach { i ->
+            scrapLikeList.add(
+                PrintEntirePostDto(i.postId.postId!!, i.postId.userId.userId!!,
+                    i.postId.subject, i.postId.date, i.postId.countComment, i.postId.countLike)
+            )
+        }
+        return scrapLikeList
+    }
+}

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
@@ -2,18 +2,13 @@ package sogong.sogongSpring.service
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import sogong.sogongSpring.dto.EntireCommentDto
-import sogong.sogongSpring.dto.EntirePostDto
-import sogong.sogongSpring.dto.ScrapLikeDto
-import sogong.sogongSpring.entity.EntireCommentEntity
-import sogong.sogongSpring.entity.EntirePostEntity
-import sogong.sogongSpring.entity.ScrapLikeEntity
-import sogong.sogongSpring.entity.UserLoginEntity
-import sogong.sogongSpring.repository.EntireCommentRepository
-import sogong.sogongSpring.repository.EntirePostRepository
-import sogong.sogongSpring.repository.ScrapLikeRepository
-import sogong.sogongSpring.repository.UserLoginRepository
+import sogong.sogongSpring.dto.board.EntireCommentDto
+import sogong.sogongSpring.dto.board.EntirePostDto
+import sogong.sogongSpring.dto.board.ScrapLikeDto
+import sogong.sogongSpring.entity.*
+import sogong.sogongSpring.repository.*
 import java.util.*
+import javax.transaction.Transactional
 
 
 @Service
@@ -24,9 +19,14 @@ class BoardService {
     lateinit var userLoginRepository : UserLoginRepository
     @Autowired //댓글을 저장하려는 변수
     lateinit var entireCommentRepository: EntireCommentRepository
+    @Autowired
+    lateinit var hotPostRepository: HotPostRepository
+    @Autowired
+    lateinit var bestPostRepository: BestPostRepository
 
     //MutableList<EntirePostEntity>로 반환하면 Json 형태로 잘 돌려보내줘요.
-    fun saveBoard(entirePostDto: EntirePostDto): MutableList<EntirePostEntity> {
+    @Transactional
+    fun saveBoard(entirePostDto: EntirePostDto): EntirePostEntity {
 
         //Board DTO에 저장된 userid를 User Repository에 조회해보자!
         val postUserId = userLoginRepository.findById(entirePostDto.userid)
@@ -35,36 +35,46 @@ class BoardService {
         if (postUserId.isPresent) {
             //DTO를 EntirePostEntity에 저장해라.
             val entirePostEntity = EntirePostEntity(
-                userid = postUserId.get(), //위에서 userid를 조회한 객체를 Entity의 userid 값으로 넣자!
+                userId = postUserId.get(), //위에서 userid를 조회한 객체를 Entity의 userid 값으로 넣자!
                 subject = entirePostDto.subject, //나머지들은 그냥 있는 그대로 넣기.
                 content = entirePostDto.content,
                 date = Date(), //얘는 수정할거임 나중에.
                 picture = entirePostDto.picture,
                 hashtag = entirePostDto.hashtag,
-                countcomment = entirePostDto.countcomment,
-                countlike = entirePostDto.countlike
+                countComment = entirePostDto.countcomment,
+                countLike = entirePostDto.countlike
             )
             entirePostRepository.save(entirePostEntity) //자 이제 Repository에 저장해주세요
-            return entirePostRepository.findAll() //전체 글 조회해주세요^^
+            return entirePostEntity //전체 글 조회해주세요^^
         }
         //userid가 조회가 되지 않을 때!
         else throw java.lang.IllegalArgumentException("Userid Error!!!!") //응 userid 잘못된거니까 던져
     }
 
     //////////////////////////////////////////////////////////////
-    fun saveComment(entireCommentDto: EntireCommentDto) : MutableList<EntireCommentEntity>{
+    @Transactional
+    fun saveComment(entireCommentDto: EntireCommentDto) : EntireCommentEntity{
         val commentUserId = userLoginRepository.findById(entireCommentDto.userid)
         val commentPostId = entirePostRepository.findById(entireCommentDto.postid)
 
         if(commentUserId.isPresent and commentPostId.isPresent){
             val entireCommentEntity = EntireCommentEntity(
-                userid = commentUserId.get(),
-                postid = commentPostId.get(),
+                userId = commentUserId.get(),
+                postId = commentPostId.get(),
                 date = Date(),
                 content = entireCommentDto.content
             )
-            entireCommentRepository.save(entireCommentEntity)
-            return entireCommentRepository.findAll()
+            entireCommentRepository.save(entireCommentEntity) //댓글 저장
+            //게시글의 댓글 수가 1씩 증가하도록 저장.
+            commentPostId.get().countComment = commentPostId.get().countComment + 1
+            entirePostRepository.save(commentPostId.get())
+
+            if (commentPostId.get().countComment == 10){
+                val hotPostEntity = HotPostEntity(postId=commentPostId.get(), date=Date())
+                hotPostRepository.save(hotPostEntity)
+            }
+
+            return entireCommentEntity
         }
         else throw java.lang.IllegalArgumentException("Userid & Postid Error!!!")
     }
@@ -72,19 +82,46 @@ class BoardService {
     @Autowired
     lateinit var scrapLikeRepository: ScrapLikeRepository
 
-    fun saveScrapLike(scrapLikeDto: ScrapLikeDto) : MutableList<ScrapLikeEntity>{
+    @Transactional
+    fun saveScrapLike(scrapLikeDto: ScrapLikeDto){
         val scrapLikeUserId = userLoginRepository.findById(scrapLikeDto.userid)
         val scrapLikePostId = entirePostRepository.findById(scrapLikeDto.postid)
 
-        if(scrapLikeUserId.isPresent and scrapLikePostId.isPresent){
-            val scrapLikeEntity = ScrapLikeEntity(
-                userid = scrapLikeUserId.get(),
-                postid = scrapLikePostId.get(),
-                category = scrapLikeDto.category
-            )
-            scrapLikeRepository.save(scrapLikeEntity)
-            return scrapLikeRepository.findAll()
-        }
-        else throw java.lang.IllegalArgumentException("Userid & Postid Error!!")
+        //usreid와 postid가 존재한다면
+        if (scrapLikeUserId.isPresent and scrapLikePostId.isPresent) {
+            //스크랩과 좋아요가 미리 있으면 취소해주기 위한 변수
+            val editScrapLike = scrapLikeRepository.findByUserIdAndPostIdAndCategory(
+                scrapLikeUserId.get(), scrapLikePostId.get(), scrapLikeDto.category)
+            val countLike : Int = scrapLikePostId.get().countLike //게시글 내 좋아요 개수
+
+            //스크랩, 좋아요가 없으면 등록
+            if(editScrapLike == null) {
+                val scrapLikeEntity = ScrapLikeEntity(
+                    userId = scrapLikeUserId.get(),
+                    postId = scrapLikePostId.get(),
+                    category = scrapLikeDto.category
+                )
+                scrapLikeRepository.save(scrapLikeEntity)
+                //좋아요일 때 게시글의 좋아요 수가 1씩 증가하도록 저장.
+                if (scrapLikeDto.category) {
+                    scrapLikePostId.get().countLike = countLike + 1
+                    entirePostRepository.save(scrapLikePostId.get())
+
+                    //좋아요가 10개 될 때 best 게시글에 저장.
+                    if(scrapLikePostId.get().countLike == 10){
+                        val bestPostEntity = BestPostEntity(postId=scrapLikePostId.get(), date=Date())
+                        bestPostRepository.save(bestPostEntity)
+                    }
+                }
+            }
+            //스크랩, 좋아요가 있으면 삭제
+            else {
+                val scrapid : Long = editScrapLike.scrapId!!
+                scrapLikeRepository.deleteById(scrapid)
+                //좋아요를 취소하므로 좋아요 수가 1씩 감소하도록 저장.
+                scrapLikePostId.get().countLike = countLike - 1
+            }
+        } else throw java.lang.IllegalArgumentException("Userid & Postid Error!!")
     }
+
 }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
@@ -2,10 +2,16 @@ package sogong.sogongSpring.service
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import sogong.sogongSpring.dto.EntireCommentDto
 import sogong.sogongSpring.dto.EntirePostDto
+import sogong.sogongSpring.dto.ScrapLikeDto
+import sogong.sogongSpring.entity.EntireCommentEntity
 import sogong.sogongSpring.entity.EntirePostEntity
+import sogong.sogongSpring.entity.ScrapLikeEntity
 import sogong.sogongSpring.entity.UserLoginEntity
+import sogong.sogongSpring.repository.EntireCommentRepository
 import sogong.sogongSpring.repository.EntirePostRepository
+import sogong.sogongSpring.repository.ScrapLikeRepository
 import sogong.sogongSpring.repository.UserLoginRepository
 import java.util.*
 
@@ -16,6 +22,8 @@ class BoardService {
     lateinit var entirePostRepository : EntirePostRepository
     @Autowired //글을 저장할 때 userid가 유효한지 검증하려는 변수
     lateinit var userLoginRepository : UserLoginRepository
+    @Autowired //댓글을 저장하려는 변수
+    lateinit var entireCommentRepository: EntireCommentRepository
 
     //MutableList<EntirePostEntity>로 반환하면 Json 형태로 잘 돌려보내줘요.
     fun saveBoard(entirePostDto: EntirePostDto): MutableList<EntirePostEntity> {
@@ -26,7 +34,7 @@ class BoardService {
         //userid가 조회가 될 때!
         if (postUserId.isPresent) {
             //DTO를 EntirePostEntity에 저장해라.
-            var entirePostEntity = EntirePostEntity(
+            val entirePostEntity = EntirePostEntity(
                 userid = postUserId.get(), //위에서 userid를 조회한 객체를 Entity의 userid 값으로 넣자!
                 subject = entirePostDto.subject, //나머지들은 그냥 있는 그대로 넣기.
                 content = entirePostDto.content,
@@ -36,12 +44,47 @@ class BoardService {
                 countcomment = entirePostDto.countcomment,
                 countlike = entirePostDto.countlike
             )
-            var aa = entirePostRepository.save(entirePostEntity) //자 이제 Repository에 저장해주세요
+            entirePostRepository.save(entirePostEntity) //자 이제 Repository에 저장해주세요
             return entirePostRepository.findAll() //전체 글 조회해주세요^^
         }
         //userid가 조회가 되지 않을 때!
-        else {
-            throw java.lang.IllegalArgumentException("Userid Error!!!!") //응 userid 잘못된거니까 던져
+        else throw java.lang.IllegalArgumentException("Userid Error!!!!") //응 userid 잘못된거니까 던져
+    }
+
+    //////////////////////////////////////////////////////////////
+    fun saveComment(entireCommentDto: EntireCommentDto) : MutableList<EntireCommentEntity>{
+        val commentUserId = userLoginRepository.findById(entireCommentDto.userid)
+        val commentPostId = entirePostRepository.findById(entireCommentDto.postid)
+
+        if(commentUserId.isPresent and commentPostId.isPresent){
+            val entireCommentEntity = EntireCommentEntity(
+                userid = commentUserId.get(),
+                postid = commentPostId.get(),
+                date = Date(),
+                content = entireCommentDto.content
+            )
+            entireCommentRepository.save(entireCommentEntity)
+            return entireCommentRepository.findAll()
         }
+        else throw java.lang.IllegalArgumentException("Userid & Postid Error!!!")
+    }
+    ////////////////////////////////////////////////////////////////
+    @Autowired
+    lateinit var scrapLikeRepository: ScrapLikeRepository
+
+    fun saveScrapLike(scrapLikeDto: ScrapLikeDto) : MutableList<ScrapLikeEntity>{
+        val scrapLikeUserId = userLoginRepository.findById(scrapLikeDto.userid)
+        val scrapLikePostId = entirePostRepository.findById(scrapLikeDto.postid)
+
+        if(scrapLikeUserId.isPresent and scrapLikePostId.isPresent){
+            val scrapLikeEntity = ScrapLikeEntity(
+                userid = scrapLikeUserId.get(),
+                postid = scrapLikePostId.get(),
+                category = scrapLikeDto.category
+            )
+            scrapLikeRepository.save(scrapLikeEntity)
+            return scrapLikeRepository.findAll()
+        }
+        else throw java.lang.IllegalArgumentException("Userid & Postid Error!!")
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,10 @@
-spring.datasource.url=jdbc:mysql://34.64.97.213:3306/sogong_sogong?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
-spring.datasource.username=webadmin
-spring.datasource.password=sogongsogong
+#spring.datasource.url=jdbc:mysql://34.64.97.213:3306/sogong_sogong?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+#spring.datasource.username=webadmin
+#spring.datasource.password=sogongsogong
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/sogong_sogong?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=leakea2008
 
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/sogong_sogong?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=leakea2008
+spring.datasource.password=0000
 
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
### First Commit(03/09/2022)
1. 댓글 : /board/registerComment
2. 스크랩, 좋아요 : /board/saveScrapLike 로 PostMapping 완료.
3. Date를 입력받는 Dto에서 전부 기본값 null로 처리
 - 프론트에서 넘겨받지 않고, 서버에 저장할 때의 시간을 자동 저장할 것.
 - Dto에서 date를 삭제할 수 있으나 프론트와 상의 후에 진행하겠음.
4. Entity에서 외래키 참조한 모든 Column을 Json Ignore 처리
 - Postman으로 Json 조회 결과, json Serialize 시 Lazy Fetch인 외래키가 참조된 column은 오류를 일으켜 annotation 추가
 - https://ahndding.tistory.com/24 참고.
 - 단, 추후에 Response를 Dto로 넘길경우 필요없으므로 삭제 예정.

### Second Commit (03/11/2022)
1. 게시판 대부분의 서비스인 등록, 조회, 수정, 삭제 서비스 완료. (진행 상황은 소공소공 Notion 백엔드의 백로그 참고)
2. BoardPrintService에서 로직문제로 N+1문제가 발생할 것으로 추정.
 - 앱 구동에 큰 문제가 되진 않지만(단 게시글, 댓글이 쌓이면 지연되는 단점이 발생) 여유가 있다면 fetch join으로 수정할 예정.
3. 등록, 수정 시 반환값 정리되지 않았음. **프론트에서 원하시는 틀이 있으면 말씀해주세요^^**