### PR TITLE
해시태그 관련 Service

### DIFF
--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.*
 import sogong.sogongSpring.dto.boardedit.EditPostCommentAuthDto
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.board.EntirePostDto
-import sogong.sogongSpring.dto.board.PostHashtagDto
 import sogong.sogongSpring.dto.board.ScrapLikeDto
 import sogong.sogongSpring.dto.boardedit.DeleteCommentDto
 import sogong.sogongSpring.dto.boardedit.DeletePostDto
@@ -35,11 +34,6 @@ class BoardController {
     @PostMapping("/registPost")
     fun registPost(@RequestBody entirePostDto : EntirePostDto): EntirePostEntity {
         return boardService.saveBoard(entirePostDto) //바로 Service로 갑니다^^
-    }
-
-    @PostMapping("/registPostHashtag")
-    fun registPostHashtag(@RequestBody postHashtagDto: PostHashtagDto){
-        boardService.savePostHashtag(postHashtagDto)
     }
 
     @PostMapping("/registComment")

--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*
 import sogong.sogongSpring.dto.boardedit.EditPostCommentAuthDto
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.board.EntirePostDto
+import sogong.sogongSpring.dto.board.PostHashtagDto
 import sogong.sogongSpring.dto.board.ScrapLikeDto
 import sogong.sogongSpring.dto.boardedit.DeleteCommentDto
 import sogong.sogongSpring.dto.boardedit.DeletePostDto
@@ -34,6 +35,11 @@ class BoardController {
     @PostMapping("/registPost")
     fun registPost(@RequestBody entirePostDto : EntirePostDto): EntirePostEntity {
         return boardService.saveBoard(entirePostDto) //바로 Service로 갑니다^^
+    }
+
+    @PostMapping("/registPostHashtag")
+    fun registPostHashtag(@RequestBody postHashtagDto: PostHashtagDto){
+        boardService.savePostHashtag(postHashtagDto)
     }
 
     @PostMapping("/registComment")

--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -1,5 +1,7 @@
 package sogong.sogongSpring.controller
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.web.bind.annotation.*
 import sogong.sogongSpring.dto.boardedit.EditPostCommentAuthDto
 import sogong.sogongSpring.dto.board.EntireCommentDto
@@ -70,12 +72,12 @@ class BoardController {
     }
 
     @GetMapping("/printEntirePost")
-    fun printPost() : MutableList<PrintEntirePostDto>{
-        return boardPrintService.printEntirePost()
+    fun printPost(pageable: Pageable) : Page<EntirePostEntity> {
+        return boardPrintService.printEntirePost(pageable)
     }
 
     @GetMapping("/printCommentByPost")
-    fun printComment(@RequestParam("postId") postId : Long): MutableList<EntireCommentDto>{
+    fun printComment(@RequestParam("postId") postId : Long): MutableList<EntireCommentEntity>{
         return boardPrintService.printComment(postId)
     }
 
@@ -83,5 +85,15 @@ class BoardController {
     fun printScrapLike(@RequestParam("userId") userId:Long,
                        @RequestParam("scrapLike") scrapLike:Boolean) : MutableList<PrintEntirePostDto>{
         return boardPrintService.printScrapLike(userId, scrapLike)
+    }
+
+    @GetMapping("/printHotPost")
+    fun printHotPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+        return boardPrintService.printHotPost(pageable)
+    }
+
+    @GetMapping("/printBestPost")
+    fun printBestPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+        return boardPrintService.printBestPost(pageable)
     }
 }

--- a/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/BoardController.kt
@@ -88,12 +88,12 @@ class BoardController {
     }
 
     @GetMapping("/printHotPost")
-    fun printHotPost(pageable: Pageable) : MutableList<EntirePostEntity>{
-        return boardPrintService.printHotPost(pageable)
+    fun printHotPost(pageable: Pageable) : List<EntirePostEntity>{
+        return boardPrintService.printHotPost(pageable).content //content만 적용
     }
 
     @GetMapping("/printBestPost")
-    fun printBestPost(pageable: Pageable) : MutableList<EntirePostEntity>{
-        return boardPrintService.printBestPost(pageable)
+    fun printBestPost(pageable: Pageable) : Page<EntirePostEntity>{
+        return boardPrintService.printBestPost(pageable) //page 전체만 적용
     }
 }

--- a/src/main/kotlin/sogong/sogongSpring/controller/HashtagController.kt
+++ b/src/main/kotlin/sogong/sogongSpring/controller/HashtagController.kt
@@ -1,0 +1,23 @@
+package sogong.sogongSpring.controller
+
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import sogong.sogongSpring.dto.hashtag.PostHashtagDto
+import sogong.sogongSpring.service.HashtagService
+
+@RestController
+@RequestMapping("/hashtag")
+class HashtagController {
+    var hashtagService : HashtagService
+
+    constructor(hashtagService: HashtagService) {
+        this.hashtagService = hashtagService
+    }
+
+    @PostMapping("/registPostHashtag")
+    fun registPostHashtag(@RequestBody postHashtagDto: PostHashtagDto){
+        hashtagService.savePostHashtag(postHashtagDto)
+    }
+}

--- a/src/main/kotlin/sogong/sogongSpring/dto/BestPostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/BestPostDto.kt
@@ -1,10 +1,10 @@
 package sogong.sogongSpring.dto
 
 import java.io.Serializable
-import java.util.*
+import java.time.LocalDateTime
 
 data class BestPostDto(
     val bestid: Long? = null,
     val postid: Long,
-    var date: Date? = null //수정 예정
+    var date: LocalDateTime? = null //수정 예정
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/HotPostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/HotPostDto.kt
@@ -1,10 +1,10 @@
 package sogong.sogongSpring.dto
 
 import java.io.Serializable
-import java.util.*
+import java.time.LocalDateTime
 
 data class HotPostDto(
     val hotid: Long? = null,
     val postid: Long,
-    var date: Date? = null //수정 예정
+    var date: LocalDateTime? = null //수정 예정
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/EntireCommentDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/EntireCommentDto.kt
@@ -1,12 +1,13 @@
 package sogong.sogongSpring.dto.board
 
 import java.io.Serializable
-import java.util.*
+import java.time.LocalDateTime
+
 
 data class EntireCommentDto(
     val commentid: Long? = null,
     val userid: Long,
     val postid: Long,
-    var date: Date ?= null, //수정 예정
+    var date: LocalDateTime ?= null, //수정 예정
     var content: String
 ) : Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/EntirePostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/EntirePostDto.kt
@@ -1,14 +1,14 @@
 package sogong.sogongSpring.dto.board
 
 import java.io.Serializable
-import java.util.*
+import java.time.LocalDateTime
 
 data class EntirePostDto(
     val postid: Long? = null,
     val userid: Long,
     var subject: String,
     var content: String,
-    var date: Date ?= null, //null빼야함 수정바람.
+    var date: LocalDateTime ?= null, //null빼야함 수정바람.
     var picture: String? = null,
     var hashtag: String,
     var countcomment: Int = 0,

--- a/src/main/kotlin/sogong/sogongSpring/dto/board/PostHashtagDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/board/PostHashtagDto.kt
@@ -1,0 +1,7 @@
+package sogong.sogongSpring.dto.board
+
+
+data class PostHashtagDto(
+    val postId : Long,
+    val hashName : List<String>
+):java.io.Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/boardprint/PrintEntirePostDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/boardprint/PrintEntirePostDto.kt
@@ -1,13 +1,13 @@
 package sogong.sogongSpring.dto.boardprint
 
 import java.io.Serializable
-import java.util.*
+import java.time.LocalDateTime
 
 data class PrintEntirePostDto(
     val postid : Long,
     val userid : Long,
     val subject : String,
-    val date : Date,
+    val date : LocalDateTime,
     val countcomment:Int,
     val countlike:Int
 ):Serializable

--- a/src/main/kotlin/sogong/sogongSpring/dto/hashtag/PostHashtagDto.kt
+++ b/src/main/kotlin/sogong/sogongSpring/dto/hashtag/PostHashtagDto.kt
@@ -1,4 +1,4 @@
-package sogong.sogongSpring.dto.board
+package sogong.sogongSpring.dto.hashtag
 
 
 data class PostHashtagDto(

--- a/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/BestPostEntity.kt
@@ -1,8 +1,7 @@
 package sogong.sogongSpring.entity
 
 import lombok.NoArgsConstructor
-import org.springframework.format.annotation.DateTimeFormat
-import java.util.*
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
@@ -17,7 +16,6 @@ data class BestPostEntity(
     @JoinColumn(name = "postId", nullable = false)
     val postId : EntirePostEntity,
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    var date : Date
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    var date : LocalDateTime
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntireCommentEntity.kt
@@ -3,6 +3,7 @@ package sogong.sogongSpring.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import lombok.NoArgsConstructor
 import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
 import java.util.Date
 import javax.persistence.*
 
@@ -24,9 +25,8 @@ data class EntireCommentEntity(
     @JoinColumn(name="postId",nullable = false)
     val postId : EntirePostEntity,
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    var date : Date,
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    var date : LocalDateTime,
 
     @Column(nullable = false)
     var content : String

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import lombok.NoArgsConstructor
 import org.hibernate.annotations.GeneratorType
 import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
 import java.util.*
 import javax.persistence.*
 
@@ -26,9 +27,8 @@ data class EntirePostEntity(
     @Column(nullable = false, columnDefinition = "TEXT")
     var content: String,
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    var date: Date,
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    var date: LocalDateTime,
 
     //추후 변경될 수 있음
     @Column

--- a/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/EntirePostEntity.kt
@@ -34,9 +34,6 @@ data class EntirePostEntity(
     @Column
     var picture: String? =null,
 
-    @Column(nullable = false, length = 50)
-    var hashtag: String,
-
     @Column(columnDefinition = "integer default 0")
     var countComment: Int = 0,
 

--- a/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HashtagDbEntity.kt
@@ -12,5 +12,8 @@ data class HashtagDbEntity(
     val hashId : Long? = null,
 
     @Column(nullable = false, length = 45)
-    val hashName : String
+    val hashName : String,
+
+    @Column(nullable = false)
+    val category : Boolean
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/HotPostEntity.kt
@@ -2,6 +2,7 @@ package sogong.sogongSpring.entity
 
 import lombok.NoArgsConstructor
 import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
 import java.util.*
 import javax.persistence.*
 
@@ -17,7 +18,6 @@ data class HotPostEntity(
     @JoinColumn(name="postId",nullable = false)
     val postId : EntirePostEntity,
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    var date : Date
+    @Column(nullable = false, columnDefinition = "TIMESTAMP")
+    var date : LocalDateTime
 )

--- a/src/main/kotlin/sogong/sogongSpring/entity/PostHashtagEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/PostHashtagEntity.kt
@@ -1,0 +1,21 @@
+package sogong.sogongSpring.entity
+
+import lombok.NoArgsConstructor
+import javax.persistence.*
+
+@Entity
+@NoArgsConstructor
+@Table(name = "POST_HASHTAG")
+data class PostHashtagEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val postHashId : Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashId", nullable = false)
+    var hashId : HashtagDbEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId", nullable = false)
+    val postId : EntirePostEntity
+)

--- a/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
+++ b/src/main/kotlin/sogong/sogongSpring/entity/UserHashtagEntity.kt
@@ -17,7 +17,7 @@ data class UserHashtagEntity(
     val userId : UserLoginEntity,
 
     @Column(nullable = false)
-    var groupiId : Long? = null,
+    var groupId : Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="hashId", nullable = false)

--- a/src/main/kotlin/sogong/sogongSpring/repository/EntireCommentRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/EntireCommentRepository.kt
@@ -1,6 +1,8 @@
 package sogong.sogongSpring.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import sogong.sogongSpring.entity.EntireCommentEntity
 import sogong.sogongSpring.entity.EntirePostEntity
@@ -10,4 +12,7 @@ import sogong.sogongSpring.entity.UserLoginEntity
 interface EntireCommentRepository : JpaRepository<EntireCommentEntity, Long> {
     fun findByCommentIdAndUserIdAndPostId(commentId:Long, userId:UserLoginEntity, postId:EntirePostEntity) : List<EntireCommentEntity>
     fun findByPostId(postId:EntirePostEntity) : List<EntireCommentEntity>
+
+    @Query(value = "select * from entire_comment where postId = :postId", nativeQuery = true)
+    fun selectPost(@Param(value="postId") postId : Long) : MutableList<EntireCommentEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
@@ -1,5 +1,6 @@
 package sogong.sogongSpring.repository
 
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -13,8 +14,8 @@ interface EntirePostRepository : JpaRepository<EntirePostEntity, Long> {
     fun findByPostIdAndUserId(postId:Long, userId:UserLoginEntity):MutableList<EntirePostEntity>
 
     @Query(value = "select * from entire_post where countComment >= :countComment", nativeQuery = true)
-    fun findHotPost(@Param(value="countComment") countComment : Int, pageable: Pageable) : MutableList<EntirePostEntity>
+    fun findHotPost(@Param(value="countComment") countComment : Int, pageable: Pageable) : Page<EntirePostEntity>
 
     @Query(value = "select * from entire_post where countLike >= :countLike", nativeQuery = true)
-    fun findBestPost(@Param(value="countLike") countLike : Int, pageable: Pageable) : MutableList<EntirePostEntity>
+    fun findBestPost(@Param(value="countLike") countLike : Int, pageable: Pageable) : Page<EntirePostEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/EntirePostRepository.kt
@@ -1,11 +1,20 @@
 package sogong.sogongSpring.repository
 
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import sogong.sogongSpring.entity.EntirePostEntity
 import sogong.sogongSpring.entity.UserLoginEntity
 
 @Repository
 interface EntirePostRepository : JpaRepository<EntirePostEntity, Long> {
-    fun findByPostIdAndUserId(postId:Long, userId:UserLoginEntity):List<EntirePostEntity>
+    fun findByPostIdAndUserId(postId:Long, userId:UserLoginEntity):MutableList<EntirePostEntity>
+
+    @Query(value = "select * from entire_post where countComment >= :countComment", nativeQuery = true)
+    fun findHotPost(@Param(value="countComment") countComment : Int, pageable: Pageable) : MutableList<EntirePostEntity>
+
+    @Query(value = "select * from entire_post where countLike >= :countLike", nativeQuery = true)
+    fun findBestPost(@Param(value="countLike") countLike : Int, pageable: Pageable) : MutableList<EntirePostEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/HashtagDbRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/HashtagDbRepository.kt
@@ -1,9 +1,13 @@
 package sogong.sogongSpring.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import sogong.sogongSpring.entity.HashtagDbEntity
 
 @Repository
 interface HashtagDbRepository : JpaRepository<HashtagDbEntity, Long> {
+    @Query(value = "select * from hashtag_db as h where h.hashName in (:hashName)", nativeQuery = true)
+    fun findByHashNames(@Param("hashName") hashName:List<String>) : List<HashtagDbEntity>
 }

--- a/src/main/kotlin/sogong/sogongSpring/repository/PostHashtagRepository.kt
+++ b/src/main/kotlin/sogong/sogongSpring/repository/PostHashtagRepository.kt
@@ -1,0 +1,9 @@
+package sogong.sogongSpring.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import sogong.sogongSpring.entity.PostHashtagEntity
+
+@Repository
+interface PostHashtagRepository : JpaRepository<PostHashtagEntity, Long> {
+}

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
@@ -13,6 +13,7 @@ import sogong.sogongSpring.repository.EntireCommentRepository
 import sogong.sogongSpring.repository.EntirePostRepository
 import sogong.sogongSpring.repository.ScrapLikeRepository
 import sogong.sogongSpring.repository.UserLoginRepository
+import java.time.LocalDateTime
 import java.util.*
 import javax.transaction.Transactional
 
@@ -72,7 +73,7 @@ class BoardEditService {
     @Transactional
     fun editComment(editCommentDto : EntireCommentDto){
         val editComment = entireCommentRepository.findById(editCommentDto.commentid!!).get()
-        editComment.date = Date()
+        editComment.date = LocalDateTime.now()
         editComment.content = editCommentDto.content
         //공백 content는 어떻게 처리?
     }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
@@ -64,7 +64,6 @@ class BoardEditService {
         editPost.content = editPostDto.content
         editPost.date = LocalDateTime.now()
         editPost.picture = editPostDto.picture
-        editPost.hashtag = editPostDto.hashtag
         //공백 subject, content는 어떻게 처리?
 
         return editPost

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardEditService.kt
@@ -62,7 +62,7 @@ class BoardEditService {
 
         editPost.subject = editPostDto.subject
         editPost.content = editPostDto.content
-        editPost.date = Date()
+        editPost.date = LocalDateTime.now()
         editPost.picture = editPostDto.picture
         editPost.hashtag = editPostDto.hashtag
         //공백 subject, content는 어떻게 처리?

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
@@ -5,9 +5,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.RequestMapping
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.boardprint.PrintEntirePostDto
-import sogong.sogongSpring.entity.EntireCommentEntity
-import sogong.sogongSpring.entity.EntirePostEntity
-import sogong.sogongSpring.entity.UserLoginEntity
 import sogong.sogongSpring.repository.EntireCommentRepository
 import sogong.sogongSpring.repository.EntirePostRepository
 import sogong.sogongSpring.repository.ScrapLikeRepository

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
@@ -1,10 +1,15 @@
 package sogong.sogongSpring.service
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.RequestMapping
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.boardprint.PrintEntirePostDto
+import sogong.sogongSpring.entity.EntireCommentEntity
+import sogong.sogongSpring.entity.EntirePostEntity
 import sogong.sogongSpring.repository.EntireCommentRepository
 import sogong.sogongSpring.repository.EntirePostRepository
 import sogong.sogongSpring.repository.ScrapLikeRepository
@@ -23,30 +28,35 @@ class BoardPrintService {
     private lateinit var scrapLikeRepository: ScrapLikeRepository
 
     @RequestMapping
-    fun printEntirePost() : MutableList<PrintEntirePostDto>{
-        val postList : MutableList<PrintEntirePostDto> = ArrayList()
-        val entirePost = entirePostRepository.findAll()
-        entirePost.forEach{ i ->
-            postList.add(PrintEntirePostDto(i.postId!!, i.userId.userId!!, i.subject
-                , i.date, i.countComment, i.countLike))
-        }
-        return postList
+    fun printEntirePost(pageable: Pageable) : Page<EntirePostEntity> {
+//        val postList : MutableList<PrintEntirePostDto> = ArrayList()
+//        val entirePost = entirePostRepository.findAll()
+//        entirePost.forEach{ i ->
+//            postList.add(PrintEntirePostDto(i.postId!!, i.userId.userId!!, i.subject
+//                , i.date, i.countComment, i.countLike))
+//        }
+//        return postList
+        val result = entirePostRepository.findAll(pageable)
+        return result
     }
 
+    //DTO로 바꿀것!!!
     @RequestMapping
-    fun printComment(postId:Long):MutableList<EntireCommentDto>{
-        val commentList : MutableList<EntireCommentDto> = ArrayList()
-        val findPost = entirePostRepository.findById(postId)
-        val findComment = entireCommentRepository.findByPostId(findPost.get())
-
-        findComment.forEach { i ->
-            commentList.add(
-                EntireCommentDto(i.commentId, i.userId.userId!!,
-                i.postId.postId!!, i.date, i.content)
-            )
-        }
-        return commentList
+    fun printComment(postId:Long):MutableList<EntireCommentEntity>{
+//        val commentList : MutableList<EntireCommentDto> = ArrayList()
+//        val findPost = entirePostRepository.findById(postId)
+//        val findComment = entireCommentRepository.findByPostId(findPost.get())
+//
+//        findComment.forEach { i ->
+//            commentList.add(
+//                EntireCommentDto(i.commentId, i.userId.userId!!,
+//                i.postId.postId!!, i.date, i.content)
+//            )
+//        }
+//        return commentList
+        return entireCommentRepository.selectPost(postId)
     }
+
 
     @RequestMapping
     fun printScrapLike(userId:Long, scrapLike:Boolean):MutableList<PrintEntirePostDto>{
@@ -61,5 +71,19 @@ class BoardPrintService {
             )
         }
         return scrapLikeList
+    }
+
+    //N+1 occurred
+    @RequestMapping
+    fun printHotPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+        val hotPost = entirePostRepository.findHotPost(10, pageable)
+        return hotPost
+    }
+
+    //N+1 occurred
+    @RequestMapping
+    fun printBestPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+        val bestPost = entirePostRepository.findBestPost(10, pageable)
+        return bestPost
     }
 }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardPrintService.kt
@@ -75,14 +75,14 @@ class BoardPrintService {
 
     //N+1 occurred
     @RequestMapping
-    fun printHotPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+    fun printHotPost(pageable: Pageable) : Page<EntirePostEntity>{
         val hotPost = entirePostRepository.findHotPost(10, pageable)
         return hotPost
     }
 
     //N+1 occurred
     @RequestMapping
-    fun printBestPost(pageable: Pageable) : MutableList<EntirePostEntity>{
+    fun printBestPost(pageable: Pageable) : Page<EntirePostEntity>{
         val bestPost = entirePostRepository.findBestPost(10, pageable)
         return bestPost
     }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
@@ -4,12 +4,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.board.EntirePostDto
-import sogong.sogongSpring.dto.board.PostHashtagDto
+import sogong.sogongSpring.dto.hashtag.PostHashtagDto
 import sogong.sogongSpring.dto.board.ScrapLikeDto
 import sogong.sogongSpring.entity.*
 import sogong.sogongSpring.repository.*
 import java.time.LocalDateTime
-import java.util.*
 import javax.transaction.Transactional
 
 
@@ -27,10 +26,7 @@ class BoardService {
     private lateinit var bestPostRepository: BestPostRepository
     @Autowired
     private lateinit var scrapLikeRepository: ScrapLikeRepository
-    @Autowired
-    private lateinit var postHashtagRepository: PostHashtagRepository
-    @Autowired
-    private lateinit var hashtagDbRepository: HashtagDbRepository
+
 
     //MutableList<EntirePostEntity>로 반환하면 Json 형태로 잘 돌려보내줘요.
     @Transactional
@@ -59,16 +55,6 @@ class BoardService {
     }
 
     //////////////////////////////////////////////////////////////
-
-    @Transactional
-    fun savePostHashtag(postHashtagDto: PostHashtagDto){
-        val hashIds = hashtagDbRepository.findByHashNames(postHashtagDto.hashName)
-        val postId = entirePostRepository.findById(postHashtagDto.postId)
-        hashIds.forEach { i ->
-            val postHashtagEntity = PostHashtagEntity(hashId=i, postId=postId.get())
-            postHashtagRepository.save(postHashtagEntity)
-        }
-    }
 
     @Transactional
     fun saveComment(entireCommentDto: EntireCommentDto) : EntireCommentEntity{

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
@@ -7,6 +7,7 @@ import sogong.sogongSpring.dto.board.EntirePostDto
 import sogong.sogongSpring.dto.board.ScrapLikeDto
 import sogong.sogongSpring.entity.*
 import sogong.sogongSpring.repository.*
+import java.time.LocalDateTime
 import java.util.*
 import javax.transaction.Transactional
 
@@ -40,7 +41,7 @@ class BoardService {
                 userId = postUserId.get(), //위에서 userid를 조회한 객체를 Entity의 userid 값으로 넣자!
                 subject = entirePostDto.subject, //나머지들은 그냥 있는 그대로 넣기.
                 content = entirePostDto.content,
-                date = Date(), //얘는 수정할거임 나중에.
+                date = LocalDateTime.now(),
                 picture = entirePostDto.picture,
                 hashtag = entirePostDto.hashtag,
                 countComment = entirePostDto.countcomment,
@@ -63,7 +64,7 @@ class BoardService {
             val entireCommentEntity = EntireCommentEntity(
                 userId = commentUserId.get(),
                 postId = commentPostId.get(),
-                date = Date(),
+                date = LocalDateTime.now(),
                 content = entireCommentDto.content
             )
             entireCommentRepository.save(entireCommentEntity) //댓글 저장
@@ -72,7 +73,7 @@ class BoardService {
             entirePostRepository.save(commentPostId.get())
 
             if (commentPostId.get().countComment == 10){
-                val hotPostEntity = HotPostEntity(postId=commentPostId.get(), date=Date())
+                val hotPostEntity = HotPostEntity(postId=commentPostId.get(), date=LocalDateTime.now())
                 hotPostRepository.save(hotPostEntity)
             }
 
@@ -110,7 +111,7 @@ class BoardService {
 
                     //좋아요가 10개 될 때 best 게시글에 저장.
                     if(scrapLikePostId.get().countLike == 10){
-                        val bestPostEntity = BestPostEntity(postId=scrapLikePostId.get(), date=Date())
+                        val bestPostEntity = BestPostEntity(postId=scrapLikePostId.get(), date= LocalDateTime.now())
                         bestPostRepository.save(bestPostEntity)
                     }
                 }

--- a/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/BoardService.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import sogong.sogongSpring.dto.board.EntireCommentDto
 import sogong.sogongSpring.dto.board.EntirePostDto
+import sogong.sogongSpring.dto.board.PostHashtagDto
 import sogong.sogongSpring.dto.board.ScrapLikeDto
 import sogong.sogongSpring.entity.*
 import sogong.sogongSpring.repository.*
@@ -26,6 +27,10 @@ class BoardService {
     private lateinit var bestPostRepository: BestPostRepository
     @Autowired
     private lateinit var scrapLikeRepository: ScrapLikeRepository
+    @Autowired
+    private lateinit var postHashtagRepository: PostHashtagRepository
+    @Autowired
+    private lateinit var hashtagDbRepository: HashtagDbRepository
 
     //MutableList<EntirePostEntity>로 반환하면 Json 형태로 잘 돌려보내줘요.
     @Transactional
@@ -43,7 +48,6 @@ class BoardService {
                 content = entirePostDto.content,
                 date = LocalDateTime.now(),
                 picture = entirePostDto.picture,
-                hashtag = entirePostDto.hashtag,
                 countComment = entirePostDto.countcomment,
                 countLike = entirePostDto.countlike
             )
@@ -55,6 +59,17 @@ class BoardService {
     }
 
     //////////////////////////////////////////////////////////////
+
+    @Transactional
+    fun savePostHashtag(postHashtagDto: PostHashtagDto){
+        val hashIds = hashtagDbRepository.findByHashNames(postHashtagDto.hashName)
+        val postId = entirePostRepository.findById(postHashtagDto.postId)
+        hashIds.forEach { i ->
+            val postHashtagEntity = PostHashtagEntity(hashId=i, postId=postId.get())
+            postHashtagRepository.save(postHashtagEntity)
+        }
+    }
+
     @Transactional
     fun saveComment(entireCommentDto: EntireCommentDto) : EntireCommentEntity{
         val commentUserId = userLoginRepository.findById(entireCommentDto.userid)

--- a/src/main/kotlin/sogong/sogongSpring/service/HashtagService.kt
+++ b/src/main/kotlin/sogong/sogongSpring/service/HashtagService.kt
@@ -1,0 +1,30 @@
+package sogong.sogongSpring.service
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import sogong.sogongSpring.dto.hashtag.PostHashtagDto
+import sogong.sogongSpring.entity.PostHashtagEntity
+import sogong.sogongSpring.repository.EntirePostRepository
+import sogong.sogongSpring.repository.HashtagDbRepository
+import sogong.sogongSpring.repository.PostHashtagRepository
+import javax.transaction.Transactional
+
+@Service
+class HashtagService {
+    @Autowired
+    private lateinit var postHashtagRepository: PostHashtagRepository
+    @Autowired
+    private lateinit var hashtagDbRepository: HashtagDbRepository
+    @Autowired
+    private lateinit var entirePostRepository : EntirePostRepository
+
+    @Transactional
+    fun savePostHashtag(postHashtagDto: PostHashtagDto){
+        val hashIds = hashtagDbRepository.findByHashNames(postHashtagDto.hashName)
+        val postId = entirePostRepository.findById(postHashtagDto.postId)
+        hashIds.forEach { i ->
+            val postHashtagEntity = PostHashtagEntity(hashId=i, postId=postId.get())
+            postHashtagRepository.save(postHashtagEntity)
+        }
+    }
+}


### PR DESCRIPTION
### 첫 번째 PR 
- 게시글에서 지정되는 해시태그 저장 service 추가
- POST_HASHTAG DB 추가
- ENTIRE_POST의 column인 hashtag 삭제
- 위 삭제로 인한 DTO, Service 내용 중 일부 삭제
### 두 번째 PR
- Board Controller -> Hashtag Controller 이전
- Board Service -> Hashtag Service 이전